### PR TITLE
Generate sourcemaps with css results

### DIFF
--- a/src/main/scala/sass/SassCompiler.scala
+++ b/src/main/scala/sass/SassCompiler.scala
@@ -20,10 +20,6 @@ object SassCompiler {
     try {
       val parentPath = sassFile.getParentFile.getAbsolutePath
 
-      // FIXME: Generating sourcemaps means we can't just
-      // read the result from stdout. If we want to return file content
-      // (as strings) we need to read the files from disk.
-
       val (_, dependencies) = runCompiler(
         sassCommand ++ Seq("-l", "-I", parentPath) ++ options ++ Seq(Seq(sassFile.getAbsolutePath,  ":",   outfile.getAbsolutePath).mkString, "--sourcemap")
       )

--- a/src/main/scala/sass/SbtSass.scala
+++ b/src/main/scala/sass/SbtSass.scala
@@ -42,14 +42,23 @@ object SbtSass extends AutoPlugin {
             file => {
               val fileName = fileMapToPath(file).replace(".sass", "").replace(".scss", "")
               val targetFileCss = (resourceManaged in sass).value / fileName.concat(".css")
+              val targetFileCssSourcemap = (resourceManaged in sass).value / fileName.concat(".css.map")
               val targetFileCssMin = (resourceManaged in sass).value / fileName.concat(".min.css")
+              val targetFileCssMinSourcemap = (resourceManaged in sass).value / fileName.concat(".min.css.map")
 
-              val (css, cssMin, dependencies) = SassCompiler.compile(file, sassOptions.value)
+              val dependencies = SassCompiler.compile(file, targetFileCss, targetFileCssMin, sassOptions.value)
 
-              IO.write(targetFileCss, css)
-              IO.write(targetFileCssMin, cssMin)
               val readFiles: Set[File] = (dependencies.map { new File(_) }).toSet + file
-              ((targetFileCss, targetFileCssMin), file, OpSuccess(readFiles, Set(targetFileCss, targetFileCssMin)))
+              ((targetFileCss,
+                targetFileCssMin,
+                targetFileCssSourcemap,
+                targetFileCssMinSourcemap),
+                file,
+                OpSuccess(readFiles, Set(
+                  targetFileCss,
+                  targetFileCssMin,
+                  targetFileCssSourcemap,
+                  targetFileCssMinSourcemap)))
             }
           }
           val createdFiles = (compilationResults.map {_._1})


### PR DESCRIPTION
I was so used to having the sourcemap support with sbt-less to the point that just had to have it for sass.
This works for me, but I hope you'd look over it and test it before pulling it in.

Cheers,
Owen
